### PR TITLE
feat: use limelight and trig to calculate the rotation needed to aim at the speaker

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -28,9 +28,9 @@ import frc.lib.SwerveModuleConstants;
 public final class Constants {
   public static final class SensorConstants {
     public static final class Limelight {
-      public static final double speakerAprilTag3TY = 1.442593;
-      public static final double speakerAprilTag3TX = 8.308467;
-      public static final double speakerAprilTag3TZ = 1.451102;
+      public static final double speakerAprilTag4TY = 1.442593;
+      public static final double speakerAprilTag4TX = 8.308467;
+      public static final double speakerAprilTag4TZ = 1.451102;
     }
 
     public static final class Controller {

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -66,7 +66,7 @@ public class RobotContainer {
             m_SwerveSubsystem,
             () -> m_XboxController.getRawAxis(translationAxis),
             () -> m_XboxController.getRawAxis(strafeAxis),
-            () -> m_XboxController.getRawAxis(rotationAxis),
+            () -> -m_XboxController.getRawAxis(rotationAxis),
             () -> robotCentric.getAsBoolean()));
 
     // Configure the trigger bindings

--- a/src/main/java/frc/robot/commands/AutoAlign.java
+++ b/src/main/java/frc/robot/commands/AutoAlign.java
@@ -28,11 +28,16 @@ public class AutoAlign extends Command {
     @Override
     public void initialize() {
         // get the angles from limelight
-        double floorAngle = m_LimelightSubsystem.getFloorAngle();
-        double elevation = m_LimelightSubsystem.getElevation();
-        // double floorAngle = 0;
-        // double elevation = 0;
-        canAlign = floorAngle != 0 && elevation != 0;
+        double floorAngle;
+        if (m_LimelightSubsystem.getFloorAngle() > 0) {
+            floorAngle = 1;
+        } else {
+            floorAngle = -1;
+        }
+        
+
+        // double elevation = m_LimelightSubsystem.getElevation();
+        canAlign = floorAngle != 0;
 
         // turn the robot to the correct angle
         if (!canAlign) {
@@ -40,21 +45,19 @@ public class AutoAlign extends Command {
             startTime = edu.wpi.first.wpilibj.Timer.getFPGATimestamp();
         } else {
             m_XboxController.getHID().setRumble(RumbleType.kBothRumble, 0);
-            m_SwerveSubsystem.drive(new Translation2d(0,0), floorAngle, true, false);
+            m_SwerveSubsystem.drive(new Translation2d(0,0), 4 * floorAngle, true, true);
         }
     }
 
     @Override
     public boolean isFinished() {
         // Check if the button is released or if the specified duration has passed
-        return (m_LimelightSubsystem.getFloorAngle() == 0 && canAlign && m_LimelightSubsystem.getElevation() == 0) ||
+        return (m_LimelightSubsystem.getFloorAngle() > -0.25 && m_LimelightSubsystem.getFloorAngle() < 0.25 && canAlign) ||
             (edu.wpi.first.wpilibj.Timer.getFPGATimestamp() - startTime >= duration && !canAlign);
     }
 
     @Override
     public void end(boolean interrupted) {
-        // Spin down motors
-        m_SwerveSubsystem.drive(new Translation2d(0,0), 0, true, false);
         m_XboxController.getHID().setRumble(RumbleType.kBothRumble, 0);
     }
 }

--- a/src/main/java/frc/robot/subsystems/LimelightSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/LimelightSubsystem.java
@@ -18,37 +18,41 @@ public class LimelightSubsystem extends SubsystemBase {
      */
     public void updateLimelight() {
         botposeArray = NetworkTableInstance.getDefault().getTable("limelight").getEntry("botpose").getDoubleArray(new double[6]);
-        botpose3d = new Pose3d(botposeArray[0], botposeArray[1], botposeArray[2], new Rotation3d(botposeArray[3], botposeArray[4], botposeArray[5]));
+
+        botpose3d = new Pose3d(botposeArray[0], botposeArray[1], botposeArray[2], new Rotation3d(Math.toRadians(botposeArray[3]), Math.toRadians(botposeArray[4]), Math.toRadians(botposeArray[5])));
 
         // post to smart dashboard periodically
-        SmartDashboard.putNumber("LimelightX", botpose3d.getTranslation().getX());
-        SmartDashboard.putNumber("LimelightY", botpose3d.getTranslation().getY());
+        SmartDashboard.putNumber("LimelightX", botpose3d.getX());
+        SmartDashboard.putNumber("LimelightY", botpose3d.getY());
         SmartDashboard.putNumber("Limelight Floor Angle", getFloorAngle());
         SmartDashboard.putNumber("Limelight Elevation Angle", getElevation());
+        SmartDashboard.putNumber("LimelightRotation", botpose3d.getRotation().toRotation2d().getDegrees());
     }
 
     public double getFloorAngle() {
         // x = 5.93 , y = 1.3
-        double op = botpose3d.getY() - Constants.SensorConstants.Limelight.speakerAprilTag3TY;
-        double adj = botpose3d.getX() - Constants.SensorConstants.Limelight.speakerAprilTag3TX;
+        double op = botpose3d.getY() - Constants.SensorConstants.Limelight.speakerAprilTag4TY;
+        double adj = botpose3d.getX() - Constants.SensorConstants.Limelight.speakerAprilTag4TX;
+        SmartDashboard.putNumber("Limelight floor op", op);
+        SmartDashboard.putNumber("Limelight Floor adj", adj);
 
         double trig;
-        if (op == 0 || adj == 0) {
+        if (botpose3d.getY() == 0 && botpose3d.getX() == 0) {
             trig = 0;
         } else {
             trig = Math.atan(op/adj);
         }
 
-        return Math.toDegrees(trig);
+        return -(Math.toDegrees(trig) - botpose3d.getRotation().toRotation2d().getDegrees());
     }
 
     public double getElevation() {
         // x = 5.93 , z = 
-        double adj = botpose3d.getX() - Constants.SensorConstants.Limelight.speakerAprilTag3TX;
-        double op = botpose3d.getZ() - Constants.SensorConstants.Limelight.speakerAprilTag3TZ;
+        double adj = botpose3d.getX() - Constants.SensorConstants.Limelight.speakerAprilTag4TX;
+        double op = botpose3d.getZ() - Constants.SensorConstants.Limelight.speakerAprilTag4TZ;
         
         double trig;
-        if (op == 0 || adj == 0) {
+        if (botpose3d.getZ() == 0 && botpose3d.getX() == 0) {
             trig = 0;
         } else {
             trig = Math.atan(op/adj);


### PR DESCRIPTION
TODO
- [ ]  Adjust height of speaker target
- [ ] Add secondary speaker target and switch which one is being used based on driver station alliance
- [ ] Test to see if the rotation actually works